### PR TITLE
Fix Release Note Generation

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -41,4 +41,5 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           fail_on_unmatched_files: true
+          generate_release_notes: true
           files: thesis.pdf

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,8 +1,6 @@
 name: Build LaTeX Document
 on:
   push:
-    branches:
-      - main
     tags:
       - 'v*.*.*'
   pull_request:


### PR DESCRIPTION
## Description

Fixed a minor issue with the generation of release notes not being enabled with #23. Also a bonus for #21.

Also disables builds for push actions on `main`, since it was a duplicate process.

## Checklist

- [x] Validate build without errors
- [x] Issue referenced and updated
